### PR TITLE
Avoid response decode-encode to avoid breaking large integers

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -15,6 +15,7 @@ http {
     init_by_lua_block {
         require "resty.core"
         cjson = require "cjson"
+        cjson.decode_array_with_array_mt(true)
     }
 
     set_real_ip_from DOCKER_SUBNET;


### PR DESCRIPTION
The current implementation decodes a response, changes the id back to the original request id, then reencodes the response.

This breaks for some JSON-RPC endpoints (Solana, for instance) that use large integers (i.e. larger than will fit into a double), which get reencoded as doubles.  For instance `"whatever":18446744073709551615` will become `"whatever":1.18446744073709e+19`, and this both loses precision and breaks parsers (such as some of Chainflip's Solana deserializers) that properly expect to find a u64 (but *not* a float) as that value.

This fix rewrites the lua handler to rewrite the *request* to include a dummy `"id"`, then rewrites the dummy id in the response using string substitution rather than a json decode-encode round trip.

It isn't perfect in that there's still a decode-encode pass in the *request*, and so could break *requests* with large integers in the same way but that seems to be much less common in practice than *responses* with large integers.

There's also a change here to set `cjson.decode_array_with_array_mt(true)` -- without that empty arrays `[]` in decoded json become empty dicts `{}` when reencoded, which of course also breaks things.